### PR TITLE
Added data structure to replace o(n) lookups

### DIFF
--- a/include/brainfuck.h
+++ b/include/brainfuck.h
@@ -10,6 +10,8 @@
 #define ERROR_INTERN 1
 #define ERROR_SYNTAX 2
 
+#define USING_COMMAND_STRUCTURE 1
+
 CELL* bf_execute(char* program, CELL* prog_array, CELL* ptr);
 char* bf_read_file(char* filename);
 char* bf_read_file_and_minimize(char* filename);


### PR DESCRIPTION
I added a stack structure for the commands to replace the slow O(n)
lookup. It appears to make it around 100x faster. To give context, it
completed the mandelbrot in only 30 seconds on my machine, whereas
given the progress it was making, it was on pace to finish in 50
minutes. I kept both versions, so to use mine you just go to
brainfuck.h and change USING_COMMAND_STRUCTURE to 1.

One quick thing to mention is that it does not handle any error debugging and merely assumes that the code works.
